### PR TITLE
EXPLORE-17: Implementation of CI

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -1,0 +1,31 @@
+name: Build and Push Docker Image
+on:
+    push:
+        branches:
+            - main
+            - "release/**"
+
+jobs:
+    build-and-push:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v3
+
+            - name: Log in to Docker Hub
+              uses: docker/login-action@v3
+              with:
+                  username: ${{ secrets.DOCKERHUB_USERNAME }}
+                  password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+            - name: Build and push Docker image
+              uses: docker/build-push-action@v5
+              with:
+                  context: .
+                  file: Dockerfile.prod
+                  push: true
+                  tags: ${{ secrets.DOCKERHUB_USERNAME }}/exploresg-frontend-service:latest


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the building and publishing of the Docker image for the project. The workflow is triggered on pushes to the `main` branch and any `release/**` branches, ensuring that Docker images are consistently built and pushed to Docker Hub.

**CI/CD Automation:**

* Added a `.github/workflows/docker-publish.yaml` workflow that checks out code, sets up Docker Buildx, logs into Docker Hub using repository secrets, and builds and pushes the Docker image using `Dockerfile.prod` to Docker Hub on relevant branch pushes.